### PR TITLE
Refatoração do Módulo SSH Key: Remover valor padrão, adicionar placeholder e fixar versão

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,14 @@
+language: "pt-BR"
+early_access: true
+reviews:
+  profile: "assertive"
+  request_changes_workflow: true
+  high_level_summary: true
+  poem: true
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: false
+chat:
+  auto_reply: true

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,34 @@
+name: Terraform Format, Validate, and Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Terraform
+      uses: hashicorp/setup-terraform@v2
+      with:
+        terraform_version: 1.9.3
+
+    - name: Terraform Init
+      run: terraform init
+
+    - name: Terraform Format
+      run: terraform fmt -check -recursive -diff
+
+    - name: Terraform Validate
+      run: terraform validate
+
+    - name: Terraform Test
+      run: terraform test

--- a/.github/workflows/tfsec.yml
+++ b/.github/workflows/tfsec.yml
@@ -1,0 +1,33 @@
+name: Verificar código terraform com tfsec
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '0 9 * * *'
+
+jobs:
+  tfsec:
+    name: Run tfsec sarif report
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v4
+
+      - name: Run tfsec
+        uses: aquasecurity/tfsec-sarif-action@21ded20e8ca120cd9d3d6ab04ef746477542a608
+        with:
+          sarif_file: tfsec.sarif
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          # Path to SARIF file relative to the root of the repository
+          sarif_file: tfsec.sarif

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Este módulo Terraform adiciona uma nova chave SSH à sua conta da Magalu Cloud.
 
 ```terraform
 module "ssh_key" {
-  source = "https://github.com/terraform-mgc-modules/mgc_ssh_keys.git"
+  source = "https://github.com/terraform-mgc-modules/mgc_ssh_keys.git?ref=v1.0.0"
 
   ssh_key_name  = var.ssh_key_name
   ssh_key_value = var.ssh_key_value
@@ -57,7 +57,7 @@ A chave SSH é um dado sensível e não deve ser incluída diretamente no códig
 ### Exemplo de `terraform.tfvars`
 
 ```hcl
-ssh_key_value = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIP+E3U/DpNagT79ueF+xQn9dNFUKheopjx/kIBC1qQM3"
+ssh_key_value = "ssh-ed25519 EXAMPLE_KEY_REPLACE_WITH_YOUR_ACTUAL_SSH_KEY"
 ```
 
 ### Fluxo de Utilização


### PR DESCRIPTION
- Removido o valor padrão personalizado para ssh_key_name, garantindo que não haja valores sensíveis ou personalizados no código.

* Substituída a chave SSH de exemplo por um placeholder mais óbvio (`ssh-ed25519 EXAMPLE_KEY_REPLACE_WITH_YOUR_ACTUAL_SSH_KEY`), prevenindo possíveis confusões e cópias acidentais de chaves reais.

- Adicionada uma restrição de versão à URL do módulo `source = "https://github.com/terraform-mgc-modules/mgc_ssh_keys.git?ref=v1.0.0"`, assegurando que implementações sejam reprodutíveis e evitando mudanças inesperadas devido a atualizações de versão.

Estas alterações melhoram a clareza e a segurança do módulo, além de assegurar que as implementações sejam consistentes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the Terraform module usage example for improved clarity and stability.
	- Modified sensitive data handling instructions to emphasize the use of placeholders and recommend using a `terraform.tfvars` file for sensitive information management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->